### PR TITLE
bugfix: add missing dependency safetensors==0.6.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ huggingface_hub==0.33.1
 matplotlib==3.9.3
 pandas==2.2.2
 tqdm==4.67.1
+safetensors==0.6.2


### PR DESCRIPTION
博主你好，我是从抖音找到你的 repo. Kronos 在抖音老火了，好几个视频，都几万个赞。感谢你开源了这个项目！

第一次安装的时候有个小问题我想修一下。

## 问题描述

After running `pip3 install -r requirements.txt` and `cd examples; python3 prediction_example.py`, you'll get the following error:

```
line 831, in _load_as_safetensor
    if packaging.version.parse(safetensors.__version__) < packaging.version.parse("0.4.3"):  # type: ignore [attr-defined]
NameError: name 'safetensors' is not defined
```

This is because `safetensors` is missing from `requirements.txt`

## 解决方案

Added the latest version of `safetensors (0.6.2)` to requirements.txt. Reran `pip3 install -r requirements.txt; cd examples; python3 prediction_example.py` and worked without any issues

```
cd examples; python3 prediction_example.py
████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 120/120 [00:14<00:00,  8.48it/s]
Forecasted Data Head:
                          open       high        low      close       volume        amount
timestamps
2024-06-28 14:05:00  10.797220  10.835997  10.761008  10.784127  1408.992798  1.500080e+06
2024-06-28 14:10:00  10.790064  10.811324  10.780157  10.798835   418.252563  4.505680e+05
2024-06-28 14:15:00  10.794492  10.800914  10.768769  10.773741   942.297546  1.006498e+06
2024-06-28 14:20:00  10.769301  10.795750  10.760875  10.785958   600.029785  6.201486e+05
2024-06-28 14:25:00  10.790550  10.802792  10.702821  10.743479  1875.233643  1.959654e+06
```

<img width="790" height="619" alt="Screenshot 2025-09-01 at 1 06 48 AM" src="https://github.com/user-attachments/assets/b5c5ce7c-de1f-4492-aea8-d1723c8f5119" />

