### PR TITLE
Fixes #223 : remove incompatible numpy pin from webui requirements

### DIFF
--- a/webui/requirements.txt
+++ b/webui/requirements.txt
@@ -1,7 +1,6 @@
 flask==2.3.3
 flask-cors==4.0.0
 pandas==2.2.2
-numpy==1.24.3
 plotly==5.17.0
 torch>=2.1.0
 huggingface_hub==0.33.1

--- a/webui/requirements.txt
+++ b/webui/requirements.txt
@@ -1,6 +1,7 @@
 flask==2.3.3
 flask-cors==4.0.0
 pandas==2.2.2
+numpy>=1.26.0
 plotly==5.17.0
 torch>=2.1.0
 huggingface_hub==0.33.1


### PR DESCRIPTION
- webui/requirements.txt pinned numpy==1.24.3 while also requiring pandas==2.2.2
- pandas==2.2.2 requires a newer NumPy, so the dependency set is unsatisfiable
- This change removes the incompatible NumPy pin and restores installability for the Web UI requirements, including Python 3.12 setups
Fixes #223 