### PR TITLE
fix: use torch.topk instead of calling top_k int parameter as a function in sample_from_logits

### DIFF
--- a/model/kronos.py
+++ b/model/kronos.py
@@ -317,7 +317,7 @@ class Kronos(nn.Module, PyTorchModelHubMixin):
         Args:
             context (torch.Tensor): Context representation from the transformer (output of decode_s1).
                                      Shape: [batch_size, seq_len, d_model]
-            s1_ids (torch.torch.Tensor): Input tensor of s1 token IDs. Shape: [batch_size, seq_len]
+            s1_ids (torch.Tensor): Input tensor of s1 token IDs. Shape: [batch_size, seq_len]
             padding_mask (torch.Tensor, optional): Mask for padding tokens. Shape: [batch_size, seq_len]. Defaults to None.
 
         Returns:
@@ -379,7 +379,7 @@ def sample_from_logits(logits, temperature=1.0, top_k=None, top_p=None, sample_l
     probs = F.softmax(logits, dim=-1)
 
     if not sample_logits:
-        _, x = top_k(probs, k=1, dim=-1)
+        _, x = torch.topk(probs, k=1, dim=-1)
     else:
         x = torch.multinomial(probs, num_samples=1)
 


### PR DESCRIPTION
## Summary

Closes #231

## Problem

In `model/kronos.py`, the `sample_from_logits` function (line 373–386) has a logic bug in the greedy-decode branch:

```python
if not sample_logits:
    _, x = top_k(probs, k=1, dim=-1)  # BUG: top_k is an int, not callable
```

`top_k` is an **integer parameter** of `sample_from_logits`, not a function. Calling it raises:
```
TypeError: 'int' object is not callable
```

This crashes any inference path that uses greedy decoding (`sample_logits=False`).

## Fix

Replace with the correct PyTorch built-in:

```python
if not sample_logits:
    _, x = torch.topk(probs, k=1, dim=-1)
```

Also fixed a docstring typo in `decode_s2()`: `torch.torch.Tensor` → `torch.Tensor`.

## Testing

The fix uses `torch.topk` which is the standard PyTorch API for selecting the top-k elements. When `k=1`, it returns the greedy (argmax) token, which is the intended behavior.