### PR TITLE
fix: preserve batch dimension in tokenizer and predictor training

### DIFF
--- a/finetune/train_predictor.py
+++ b/finetune/train_predictor.py
@@ -93,8 +93,8 @@ def train_model(model, tokenizer, device, config, save_dir, logger, rank, world_
         valid_dataset.set_epoch_seed(0)
 
         for i, (batch_x, batch_x_stamp) in enumerate(train_loader):
-            batch_x = batch_x.squeeze(0).to(device, non_blocking=True)
-            batch_x_stamp = batch_x_stamp.squeeze(0).to(device, non_blocking=True)
+            batch_x = batch_x.to(device, non_blocking=True)
+            batch_x_stamp = batch_x_stamp.to(device, non_blocking=True)
 
             # Tokenize input data on-the-fly
             with torch.no_grad():
@@ -137,8 +137,8 @@ def train_model(model, tokenizer, device, config, save_dir, logger, rank, world_
         val_batches_processed_rank = 0
         with torch.no_grad():
             for batch_x, batch_x_stamp in val_loader:
-                batch_x = batch_x.squeeze(0).to(device, non_blocking=True)
-                batch_x_stamp = batch_x_stamp.squeeze(0).to(device, non_blocking=True)
+                batch_x = batch_x.to(device, non_blocking=True)
+                batch_x_stamp = batch_x_stamp.to(device, non_blocking=True)
 
                 token_seq_0, token_seq_1 = tokenizer.encode(batch_x, half=True)
                 token_in = [token_seq_0[:, :-1], token_seq_1[:, :-1]]

--- a/finetune/train_tokenizer.py
+++ b/finetune/train_tokenizer.py
@@ -124,7 +124,7 @@ def train_model(model, device, config, save_dir, logger, rank, world_size):
         valid_dataset.set_epoch_seed(0)  # Keep validation sampling consistent
 
         for i, (ori_batch_x, _) in enumerate(train_loader):
-            ori_batch_x = ori_batch_x.squeeze(0).to(device, non_blocking=True)
+            ori_batch_x = ori_batch_x.to(device, non_blocking=True)
 
             # --- Gradient Accumulation Loop ---
             current_batch_total_loss = 0.0
@@ -176,7 +176,7 @@ def train_model(model, device, config, save_dir, logger, rank, world_size):
         val_sample_count_rank = 0
         with torch.no_grad():
             for ori_batch_x, _ in val_loader:
-                ori_batch_x = ori_batch_x.squeeze(0).to(device, non_blocking=True)
+                ori_batch_x = ori_batch_x.to(device, non_blocking=True)
                 zs, _, _, _ = model(ori_batch_x)
                 _, z = zs
                 val_loss_item = F.mse_loss(z, ori_batch_x)

--- a/finetune_csv/finetune_tokenizer.py
+++ b/finetune_csv/finetune_tokenizer.py
@@ -190,7 +190,7 @@ def train_tokenizer(model, device, config, save_dir, logger):
             train_sampler.set_epoch(epoch)
         
         for batch_idx, (ori_batch_x, _) in enumerate(train_loader):
-            ori_batch_x = ori_batch_x.squeeze(0).to(device, non_blocking=True)
+            ori_batch_x = ori_batch_x.to(device, non_blocking=True)
             
             current_batch_total_loss = 0.0
             for j in range(accumulation_steps):
@@ -239,7 +239,7 @@ def train_tokenizer(model, device, config, save_dir, logger):
         
         with torch.no_grad():
             for ori_batch_x, _ in val_loader:
-                ori_batch_x = ori_batch_x.squeeze(0).to(device, non_blocking=True)
+                ori_batch_x = ori_batch_x.to(device, non_blocking=True)
                 zs, _, _, _ = (model.module if use_ddp else model)(ori_batch_x)
                 _, z = zs
                 val_loss_item = F.mse_loss(z, ori_batch_x)


### PR DESCRIPTION
## Summary

Fixes a shape bug in training when a DataLoader batch has size 1.

## Details

`CustomKlineDataset` and `QlibDataset` return per-sample tensors with shape `(seq_len, features)`.
After collation, batches are already shaped `(batch, seq_len, features)`.

The training scripts were calling `squeeze(0)`, which collapses a batch of size 1 into 2D and causes runtime failures like:

`ValueError: not enough values to unpack (expected 3, got 2)`

This change removes the unsafe `squeeze(0)` calls from the tokenizer and predictor training paths.

Closes #222
