### PR TITLE
refactor: extract shared utilities to eliminate finetune code duplication

### DIFF
--- a/finetune/utils/common.py
+++ b/finetune/utils/common.py
@@ -1,0 +1,107 @@
+"""
+Shared utilities for Kronos finetune scripts.
+
+Consolidates duplicated helpers from finetune_csv/ into a single module:
+- setup_logging: configurable logger with rotating file handler
+- create_dataloaders: build train/val DataLoaders (with optional DDP)
+- create_tokenizer_from_config: random-init a KronosTokenizer from config.json
+- create_predictor_from_config: random-init a Kronos predictor from config.json
+"""
+
+import os
+import json
+import datetime
+import logging
+from logging.handlers import RotatingFileHandler
+
+import torch
+import torch.distributed as dist
+from torch.utils.data import DataLoader
+from torch.utils.data.distributed import DistributedSampler
+
+
+def setup_logging(name, log_dir, rank=0):
+    os.makedirs(log_dir, exist_ok=True)
+    logger = logging.getLogger(f"{name}_rank_{rank}")
+    logger.setLevel(logging.INFO)
+    if logger.handlers:
+        return logger
+    log_file = os.path.join(log_dir, f"{name}_rank_{rank}.log")
+    file_handler = RotatingFileHandler(log_file, maxBytes=10*1024*1024, backupCount=5, encoding='utf-8')
+    file_handler.setLevel(logging.INFO)
+    console_handler = None
+    if rank == 0:
+        console_handler = logging.StreamHandler()
+        console_handler.setLevel(logging.INFO)
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
+    file_handler.setFormatter(formatter)
+    if console_handler is not None:
+        console_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+    if console_handler is not None:
+        logger.addHandler(console_handler)
+    logger.info(f"=== {name} Started ===")
+    logger.info(f"Log Directory: {log_dir}")
+    logger.info(f"Rank: {rank}")
+    logger.info(f"Timestamp: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    return logger
+
+
+def create_dataloaders(dataset_class, config):
+    if not dist.is_available() or not dist.is_initialized() or dist.get_rank() == 0:
+        print("Creating data loaders...")
+    train_dataset = dataset_class(
+        data_path=config.data_path, data_type="train",
+        lookback_window=config.lookback_window, predict_window=config.predict_window,
+        clip=config.clip, seed=config.seed,
+        train_ratio=config.train_ratio, val_ratio=config.val_ratio, test_ratio=config.test_ratio,
+    )
+    val_dataset = dataset_class(
+        data_path=config.data_path, data_type="val",
+        lookback_window=config.lookback_window, predict_window=config.predict_window,
+        clip=config.clip, seed=config.seed + 1,
+        train_ratio=config.train_ratio, val_ratio=config.val_ratio, test_ratio=config.test_ratio,
+    )
+    use_ddp = dist.is_available() and dist.is_initialized()
+    train_sampler = DistributedSampler(train_dataset, num_replicas=dist.get_world_size(), rank=dist.get_rank(), shuffle=True) if use_ddp else None
+    val_sampler = DistributedSampler(val_dataset, num_replicas=dist.get_world_size(), rank=dist.get_rank(), shuffle=False, drop_last=False) if use_ddp else None
+    train_loader = DataLoader(train_dataset, batch_size=config.batch_size, shuffle=(train_sampler is None), num_workers=config.num_workers, pin_memory=True, drop_last=True, sampler=train_sampler)
+    val_loader = DataLoader(val_dataset, batch_size=config.batch_size, shuffle=False, num_workers=config.num_workers, pin_memory=True, drop_last=False, sampler=val_sampler)
+    if not dist.is_available() or not dist.is_initialized() or dist.get_rank() == 0:
+        print(f"Training set size: {len(train_dataset)}, Validation set size: {len(val_dataset)}")
+    return train_loader, val_loader, train_dataset, val_dataset, train_sampler, val_sampler
+
+
+def create_tokenizer_from_config(config_path):
+    from model import KronosTokenizer
+    if os.path.isdir(config_path):
+        config_path = os.path.join(config_path, "config.json")
+    with open(config_path, "r") as f:
+        arch = json.load(f)
+    return KronosTokenizer(
+        d_in=arch.get("d_in", 6), d_model=arch.get("d_model", 256),
+        n_heads=arch.get("n_heads", 4), ff_dim=arch.get("ff_dim", 512),
+        n_enc_layers=arch.get("n_enc_layers", 4), n_dec_layers=arch.get("n_dec_layers", 4),
+        ffn_dropout_p=arch.get("ffn_dropout_p", 0.0), attn_dropout_p=arch.get("attn_dropout_p", 0.0),
+        resid_dropout_p=arch.get("resid_dropout_p", 0.0),
+        s1_bits=arch.get("s1_bits", 10), s2_bits=arch.get("s2_bits", 10),
+        beta=arch.get("beta", 0.05), gamma0=arch.get("gamma0", 1.0),
+        gamma=arch.get("gamma", 1.1), zeta=arch.get("zeta", 0.05),
+        group_size=arch.get("group_size", 4),
+    )
+
+
+def create_predictor_from_config(config_path):
+    from model import Kronos
+    if os.path.isdir(config_path):
+        config_path = os.path.join(config_path, "config.json")
+    with open(config_path, "r") as f:
+        arch = json.load(f)
+    return Kronos(
+        s1_bits=arch.get("s1_bits", 10), s2_bits=arch.get("s2_bits", 10),
+        n_layers=arch.get("n_layers", 12), d_model=arch.get("d_model", 832),
+        n_heads=arch.get("n_heads", 16), ff_dim=arch.get("ff_dim", 2048),
+        ffn_dropout_p=arch.get("ffn_dropout_p", 0.2), attn_dropout_p=arch.get("attn_dropout_p", 0.0),
+        resid_dropout_p=arch.get("resid_dropout_p", 0.2), token_dropout_p=arch.get("token_dropout_p", 0.0),
+        learn_te=arch.get("learn_te", True),
+    )

--- a/finetune_csv/finetune_base_model.py
+++ b/finetune_csv/finetune_base_model.py
@@ -1,25 +1,26 @@
 import os
 import sys
-import json
 import time
-import pickle
 import random
 import pandas as pd
 import numpy as np
 import torch
 import torch.nn as nn
-from torch.utils.data import Dataset, DataLoader
-from torch.utils.data.distributed import DistributedSampler
-from time import gmtime, strftime
-import logging
-from logging.handlers import RotatingFileHandler
-import datetime
+from torch.utils.data import Dataset
 import torch.distributed as dist
 from torch.nn.parallel import DistributedDataParallel as DDP
 
 sys.path.append('../')
 from model import Kronos, KronosTokenizer, KronosPredictor
 from config_loader import CustomFinetuneConfig
+
+from finetune.utils.common import (
+    setup_logging,
+    create_dataloaders as _create_dataloaders,
+    create_tokenizer_from_config,
+    create_predictor_from_config,
+)
+from finetune.utils.training_utils import set_seed, get_model_size, format_time
 
 
 class CustomKlineDataset(Dataset):
@@ -67,7 +68,7 @@ class CustomKlineDataset(Dataset):
         
         if self.data.isnull().any().any():
             print("Warning: Missing values found in data, performing forward fill")
-            self.data = self.data.fillna(method='ffill')
+            self.data = self.data.ffill()
         
         print(f"Original data time range: {self.timestamps.min()} to {self.timestamps.max()}")
         print(f"Original data total length: {len(df)} records")
@@ -134,107 +135,9 @@ class CustomKlineDataset(Dataset):
 
 
 
-def setup_logging(exp_name: str, log_dir: str, rank: int = 0) -> logging.Logger:
-    os.makedirs(log_dir, exist_ok=True)
-    
-    logger = logging.getLogger(f"basemodel_training_rank_{rank}")
-    logger.setLevel(logging.INFO)
-    
-    if logger.handlers:
-        return logger
-    
-    log_file = os.path.join(log_dir, f"basemodel_training_rank_{rank}.log")
-    file_handler = RotatingFileHandler(
-        log_file, 
-        maxBytes=10*1024*1024,
-        backupCount=5,
-        encoding='utf-8'
-    )
-    file_handler.setLevel(logging.INFO)
-    
-    console_handler = None
-    if rank == 0:
-        console_handler = logging.StreamHandler()
-        console_handler.setLevel(logging.INFO)
-    
-    formatter = logging.Formatter(
-        '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S'
-    )
-    file_handler.setFormatter(formatter)
-    if console_handler is not None:
-        console_handler.setFormatter(formatter)
-    
-    logger.addHandler(file_handler)
-    if console_handler is not None:
-        logger.addHandler(console_handler)
-    
-    logger.info(f"=== Basemodel Training Started ===")
-    logger.info(f"Experiment Name: {exp_name}")
-    logger.info(f"Log Directory: {log_dir}")
-    logger.info(f"Rank: {rank}")
-    logger.info(f"Timestamp: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
-    
-    return logger
-
-
 def create_dataloaders(config):
-    if not dist.is_available() or not dist.is_initialized() or dist.get_rank() == 0:
-        print("Creating data loaders...")
-    
-    train_dataset = CustomKlineDataset(
-        data_path=config.data_path,
-        data_type='train',
-        lookback_window=config.lookback_window,
-        predict_window=config.predict_window,
-        clip=config.clip,
-        seed=config.seed,
-        train_ratio=config.train_ratio,
-        val_ratio=config.val_ratio,
-        test_ratio=config.test_ratio
-    )
-    
-    val_dataset = CustomKlineDataset(
-        data_path=config.data_path,
-        data_type='val',
-        lookback_window=config.lookback_window,
-        predict_window=config.predict_window,
-        clip=config.clip,
-        seed=config.seed + 1,
-        train_ratio=config.train_ratio,
-        val_ratio=config.val_ratio,
-        test_ratio=config.test_ratio
-    )
-    
-    use_ddp = dist.is_available() and dist.is_initialized()
-    train_sampler = DistributedSampler(train_dataset, num_replicas=dist.get_world_size(), rank=dist.get_rank(), shuffle=True) if use_ddp else None
-    val_sampler = DistributedSampler(val_dataset, num_replicas=dist.get_world_size(), rank=dist.get_rank(), shuffle=False, drop_last=False) if use_ddp else None
-
-    train_loader = DataLoader(
-        train_dataset,
-        batch_size=config.batch_size,
-        shuffle=(train_sampler is None),
-        num_workers=config.num_workers,
-        pin_memory=True,
-        drop_last=True,
-        sampler=train_sampler
-    )
-    
-    val_loader = DataLoader(
-        val_dataset,
-        batch_size=config.batch_size,
-        shuffle=False,
-        num_workers=config.num_workers,
-        pin_memory=True,
-        drop_last=False,
-        sampler=val_sampler
-    )
-    
-    if not dist.is_available() or not dist.is_initialized() or dist.get_rank() == 0:
-        print(f"Training set size: {len(train_dataset)}, Validation set size: {len(val_dataset)}")
-    
-    return train_loader, val_loader, train_dataset, val_dataset, train_sampler, val_sampler
-
+    """Thin wrapper that passes CustomKlineDataset to the shared helper."""
+    return _create_dataloaders(CustomKlineDataset, config)
 
 def train_model(model, tokenizer, device, config, save_dir, logger):
     logger.info("Starting training...")
@@ -380,62 +283,24 @@ def main():
     os.makedirs(config.basemodel_save_path, exist_ok=True)
     
     log_dir = os.path.join(config.base_save_path, "logs")
-    logger = setup_logging(config.exp_name, log_dir, 0)
+    logger = setup_logging("basemodel_training", log_dir, 0)
     
-    torch.manual_seed(config.seed)
-    np.random.seed(config.seed)
-    random.seed(config.seed)
+    set_seed(config.seed)
     
     logger.info("Loading pretrained model or random initialization...")
     print("Loading pretrained model or random initialization...")
     if getattr(config, 'pre_trained_tokenizer', True):
         tokenizer = KronosTokenizer.from_pretrained(config.finetuned_tokenizer_path)
     else:
-        import json, os
         print("pre_trained_tokenizer=False, randomly initializing Tokenizer architecture for training")
-        cfg_path_tok = os.path.join(config.pretrained_tokenizer_path if hasattr(config, 'pretrained_tokenizer_path') else config.finetuned_tokenizer_path, 'config.json')
-        with open(cfg_path_tok, 'r') as f:
-            arch_t = json.load(f)
-        tokenizer = KronosTokenizer(
-            d_in=arch_t.get('d_in', 6),
-            d_model=arch_t.get('d_model', 256),
-            n_heads=arch_t.get('n_heads', 4),
-            ff_dim=arch_t.get('ff_dim', 512),
-            n_enc_layers=arch_t.get('n_enc_layers', 4),
-            n_dec_layers=arch_t.get('n_dec_layers', 4),
-            ffn_dropout_p=arch_t.get('ffn_dropout_p', 0.0),
-            attn_dropout_p=arch_t.get('attn_dropout_p', 0.0),
-            resid_dropout_p=arch_t.get('resid_dropout_p', 0.0),
-            s1_bits=arch_t.get('s1_bits', 10),
-            s2_bits=arch_t.get('s2_bits', 10),
-            beta=arch_t.get('beta', 0.05),
-            gamma0=arch_t.get('gamma0', 1.0),
-            gamma=arch_t.get('gamma', 1.1),
-            zeta=arch_t.get('zeta', 0.05),
-            group_size=arch_t.get('group_size', 4)
-        )
+        tok_cfg_path = config.pretrained_tokenizer_path if hasattr(config, 'pretrained_tokenizer_path') else config.finetuned_tokenizer_path
+        tokenizer = create_tokenizer_from_config(tok_cfg_path)
 
     if getattr(config, 'pre_trained_predictor', True):
         model = Kronos.from_pretrained(config.pretrained_predictor_path)
     else:
-        import json, os
         print("pre_trained_predictor=False, randomly initializing Predictor architecture for training")
-        cfg_path = os.path.join(config.pretrained_predictor_path, 'config.json')
-        with open(cfg_path, 'r') as f:
-            arch = json.load(f)
-        model = Kronos(
-            s1_bits=arch.get('s1_bits', 10),
-            s2_bits=arch.get('s2_bits', 10),
-            n_layers=arch.get('n_layers', 12),
-            d_model=arch.get('d_model', 832),
-            n_heads=arch.get('n_heads', 16),
-            ff_dim=arch.get('ff_dim', 2048),
-            ffn_dropout_p=arch.get('ffn_dropout_p', 0.2),
-            attn_dropout_p=arch.get('attn_dropout_p', 0.0),
-            resid_dropout_p=arch.get('resid_dropout_p', 0.2),
-            token_dropout_p=arch.get('token_dropout_p', 0.0),
-            learn_te=arch.get('learn_te', True)
-        )
+        model = create_predictor_from_config(config.pretrained_predictor_path)
     
     tokenizer = tokenizer.to(device)
     model = model.to(device)

--- a/finetune_csv/finetune_tokenizer.py
+++ b/finetune_csv/finetune_tokenizer.py
@@ -1,17 +1,8 @@
 import os
 import sys
-import json
 import time
-import random
-import numpy as np
 import torch
 import torch.nn.functional as F
-from torch.utils.data import DataLoader
-from torch.utils.data.distributed import DistributedSampler
-from time import gmtime, strftime
-import datetime
-import logging
-from logging.handlers import RotatingFileHandler
 import torch.distributed as dist
 from torch.nn.parallel import DistributedDataParallel as DDP
 
@@ -21,132 +12,17 @@ from finetune_base_model import CustomKlineDataset
 from config_loader import CustomFinetuneConfig
 
 
-def set_seed(seed: int, rank: int = 0):
-    actual_seed = seed
-    random.seed(actual_seed)
-    np.random.seed(actual_seed)
-    torch.manual_seed(actual_seed)
-    if torch.cuda.is_available():
-        torch.cuda.manual_seed_all(actual_seed)
-        torch.backends.cudnn.deterministic = True
-        torch.backends.cudnn.benchmark = False
-
-
-def get_model_size(model: torch.nn.Module) -> str:
-    total_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
-    if total_params >= 1e9:
-        return f"{total_params / 1e9:.1f}B"
-    elif total_params >= 1e6:
-        return f"{total_params / 1e6:.1f}M"
-    else:
-        return f"{total_params / 1e3:.1f}K"
-
-
-def format_time(seconds: float) -> str:
-    return str(datetime.timedelta(seconds=int(seconds)))
-
-
-def setup_logging(exp_name: str, log_dir: str, rank: int = 0) -> logging.Logger:
-    os.makedirs(log_dir, exist_ok=True)
-    
-    logger = logging.getLogger(f"tokenizer_training_rank_{rank}")
-    logger.setLevel(logging.INFO)
-    
-    if logger.handlers:
-        return logger
-    
-    log_file = os.path.join(log_dir, f"tokenizer_training_rank_{rank}.log")
-    file_handler = RotatingFileHandler(
-        log_file, 
-        maxBytes=10*1024*1024,
-        backupCount=5,
-        encoding='utf-8'
-    )
-    file_handler.setLevel(logging.INFO)
-    
-    console_handler = None
-    if rank == 0:
-        console_handler = logging.StreamHandler()
-        console_handler.setLevel(logging.INFO)
-    
-    formatter = logging.Formatter(
-        '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S'
-    )
-    file_handler.setFormatter(formatter)
-    if console_handler is not None:
-        console_handler.setFormatter(formatter)
-    
-    logger.addHandler(file_handler)
-    if console_handler is not None:
-        logger.addHandler(console_handler)
-    
-    logger.info(f"=== Tokenizer Training Started ===")
-    logger.info(f"Experiment Name: {exp_name}")
-    logger.info(f"Log Directory: {log_dir}")
-    logger.info(f"Rank: {rank}")
-    logger.info(f"Timestamp: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
-    
-    return logger
+from finetune.utils.common import (
+    setup_logging,
+    create_dataloaders as _create_dataloaders,
+    create_tokenizer_from_config,
+)
+from finetune.utils.training_utils import set_seed, get_model_size, format_time
 
 
 def create_dataloaders(config):
-    if not dist.is_available() or not dist.is_initialized() or dist.get_rank() == 0:
-        print("Creating tokenizer training data loaders...")
-    
-    train_dataset = CustomKlineDataset(
-        data_path=config.data_path,
-        data_type="train",
-        lookback_window=config.lookback_window,
-        predict_window=config.predict_window,
-        clip=config.clip,
-        seed=config.seed,
-        train_ratio=config.train_ratio,
-        val_ratio=config.val_ratio,
-        test_ratio=config.test_ratio
-    )
-    
-    val_dataset = CustomKlineDataset(
-        data_path=config.data_path,
-        data_type="val",
-        lookback_window=config.lookback_window,
-        predict_window=config.predict_window,
-        clip=config.clip,
-        seed=config.seed + 1,
-        train_ratio=config.train_ratio,
-        val_ratio=config.val_ratio,
-        test_ratio=config.test_ratio
-    )
-    
-    use_ddp = dist.is_available() and dist.is_initialized()
-    train_sampler = DistributedSampler(train_dataset, num_replicas=dist.get_world_size(), rank=dist.get_rank(), shuffle=True) if use_ddp else None
-    val_sampler = DistributedSampler(val_dataset, num_replicas=dist.get_world_size(), rank=dist.get_rank(), shuffle=False, drop_last=False) if use_ddp else None
-
-    train_loader = DataLoader(
-        train_dataset,
-        batch_size=config.batch_size,
-        shuffle=(train_sampler is None),
-        num_workers=config.num_workers,
-        pin_memory=True,
-        drop_last=True,
-        sampler=train_sampler
-    )
-    
-    val_loader = DataLoader(
-        val_dataset,
-        batch_size=config.batch_size,
-        shuffle=False,
-        num_workers=config.num_workers,
-        pin_memory=True,
-        drop_last=False,
-        sampler=val_sampler
-    )
-    
-    if not dist.is_available() or not dist.is_initialized() or dist.get_rank() == 0:
-        print(f"Training set size: {len(train_dataset)}, Validation set size: {len(val_dataset)}")
-    
-    return train_loader, val_loader, train_dataset, val_dataset, train_sampler, val_sampler
-
+    """Thin wrapper that passes CustomKlineDataset to the shared helper."""
+    return _create_dataloaders(CustomKlineDataset, config)
 
 def train_tokenizer(model, device, config, save_dir, logger):
     logger.info("Starting tokenizer training...")
@@ -291,44 +167,22 @@ def main():
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     print(f"Using device: {device}")
     
-    config = CustomFinetuneConfig(args.config)
-    
     os.makedirs(config.tokenizer_save_path, exist_ok=True)
     
     log_dir = os.path.join(config.base_save_path, "logs")
-    logger = setup_logging(config.exp_name, log_dir, 0)
+    logger = setup_logging("tokenizer_training", log_dir, 0)
     
     set_seed(config.seed)
     
     # 加载预训练tokenizer
+    # Load pretrained tokenizer or random init
     if getattr(config, 'pre_trained_tokenizer', True):
         logger.info("Loading pretrained tokenizer...")
         print("Loading pretrained tokenizer...")
         tokenizer = KronosTokenizer.from_pretrained(config.pretrained_tokenizer_path)
     else:
         print("pre_trained_tokenizer=False, randomly initializing Tokenizer architecture")
-        import json, os
-        cfg_path = os.path.join(config.pretrained_tokenizer_path, 'config.json')
-        with open(cfg_path, 'r') as f:
-            arch = json.load(f)
-        tokenizer = KronosTokenizer(
-            d_in=arch.get('d_in', 6),
-            d_model=arch.get('d_model', 256),
-            n_heads=arch.get('n_heads', 4),
-            ff_dim=arch.get('ff_dim', 512),
-            n_enc_layers=arch.get('n_enc_layers', 4),
-            n_dec_layers=arch.get('n_dec_layers', 4),
-            ffn_dropout_p=arch.get('ffn_dropout_p', 0.0),
-            attn_dropout_p=arch.get('attn_dropout_p', 0.0),
-            resid_dropout_p=arch.get('resid_dropout_p', 0.0),
-            s1_bits=arch.get('s1_bits', 10),
-            s2_bits=arch.get('s2_bits', 10),
-            beta=arch.get('beta', 0.05),
-            gamma0=arch.get('gamma0', 1.0),
-            gamma=arch.get('gamma', 1.1),
-            zeta=arch.get('zeta', 0.05),
-            group_size=arch.get('group_size', 4)
-        )
+        tokenizer = create_tokenizer_from_config(config.pretrained_tokenizer_path)
     tokenizer = tokenizer.to(device)
     
     model_size = get_model_size(tokenizer)

--- a/finetune_csv/train_sequential.py
+++ b/finetune_csv/train_sequential.py
@@ -11,8 +11,15 @@ sys.path.append('../')
 from model import Kronos, KronosTokenizer, KronosPredictor
 
 from config_loader import CustomFinetuneConfig
-from finetune_tokenizer import train_tokenizer, set_seed, setup_logging as setup_tokenizer_logging
-from finetune_base_model import train_model, create_dataloaders, setup_logging as setup_basemodel_logging
+from finetune_tokenizer import train_tokenizer
+from finetune_base_model import train_model, create_dataloaders
+
+from finetune.utils.common import (
+    setup_logging,
+    create_tokenizer_from_config,
+    create_predictor_from_config,
+)
+from finetune.utils.training_utils import set_seed, get_model_size, format_time
 
 
 class SequentialTrainer:
@@ -74,9 +81,9 @@ class SequentialTrainer:
             return True
         
         log_dir = os.path.join(self.config.base_save_path, "logs")
-        logger = setup_tokenizer_logging(self.config.exp_name, log_dir, self.rank)
+        logger = setup_logging("tokenizer_training", log_dir, self.rank)
         
-        set_seed(self.config.seed)
+        set_seed(self.config.seed, self.rank)
         
         if getattr(self.config, 'pre_trained_tokenizer', True):
             logger.info("Loading pretrained tokenizer...")
@@ -86,28 +93,7 @@ class SequentialTrainer:
         else:
             if self.rank == 0:
                 print("pre_trained_tokenizer=False, randomly initializing Tokenizer architecture")
-            import json
-            cfg_path = os.path.join(self.config.pretrained_tokenizer_path, 'config.json')
-            with open(cfg_path, 'r') as f:
-                arch = json.load(f)
-            tokenizer = KronosTokenizer(
-                d_in=arch.get('d_in', 6),
-                d_model=arch.get('d_model', 256),
-                n_heads=arch.get('n_heads', 4),
-                ff_dim=arch.get('ff_dim', 512),
-                n_enc_layers=arch.get('n_enc_layers', 4),
-                n_dec_layers=arch.get('n_dec_layers', 4),
-                ffn_dropout_p=arch.get('ffn_dropout_p', 0.0),
-                attn_dropout_p=arch.get('attn_dropout_p', 0.0),
-                resid_dropout_p=arch.get('resid_dropout_p', 0.0),
-                s1_bits=arch.get('s1_bits', 10),
-                s2_bits=arch.get('s2_bits', 10),
-                beta=arch.get('beta', 0.05),
-                gamma0=arch.get('gamma0', 1.0),
-                gamma=arch.get('gamma', 1.1),
-                zeta=arch.get('zeta', 0.05),
-                group_size=arch.get('group_size', 4)
-            )
+            tokenizer = create_tokenizer_from_config(self.config.pretrained_tokenizer_path)
         tokenizer = tokenizer.to(self.device)
         
         model_size = sum(p.numel() for p in tokenizer.parameters())
@@ -160,9 +146,9 @@ class SequentialTrainer:
             return True
         
         log_dir = os.path.join(self.config.base_save_path, "logs")
-        logger = setup_basemodel_logging(self.config.exp_name, log_dir, self.rank)
+        logger = setup_logging("basemodel_training", log_dir, self.rank)
         
-        set_seed(self.config.seed)
+        set_seed(self.config.seed, self.rank)
         
         if getattr(self.config, 'pre_trained_tokenizer', True):
             logger.info("Loading fine-tuned tokenizer...")
@@ -172,28 +158,7 @@ class SequentialTrainer:
         else:
             if self.rank == 0:
                 print("pre_trained_tokenizer=False, randomly initializing Tokenizer architecture for Predictor training")
-            import json
-            cfg_path = os.path.join(self.config.pretrained_tokenizer_path, 'config.json')
-            with open(cfg_path, 'r') as f:
-                arch = json.load(f)
-            tokenizer = KronosTokenizer(
-                d_in=arch.get('d_in', 6),
-                d_model=arch.get('d_model', 256),
-                n_heads=arch.get('n_heads', 4),
-                ff_dim=arch.get('ff_dim', 512),
-                n_enc_layers=arch.get('n_enc_layers', 4),
-                n_dec_layers=arch.get('n_dec_layers', 4),
-                ffn_dropout_p=arch.get('ffn_dropout_p', 0.0),
-                attn_dropout_p=arch.get('attn_dropout_p', 0.0),
-                resid_dropout_p=arch.get('resid_dropout_p', 0.0),
-                s1_bits=arch.get('s1_bits', 10),
-                s2_bits=arch.get('s2_bits', 10),
-                beta=arch.get('beta', 0.05),
-                gamma0=arch.get('gamma0', 1.0),
-                gamma=arch.get('gamma', 1.1),
-                zeta=arch.get('zeta', 0.05),
-                group_size=arch.get('group_size', 4)
-            )
+            tokenizer = create_tokenizer_from_config(self.config.pretrained_tokenizer_path)
         tokenizer = tokenizer.to(self.device)
         
         if getattr(self.config, 'pre_trained_predictor', True):
@@ -204,24 +169,7 @@ class SequentialTrainer:
         else:
             if self.rank == 0:
                 print("pre_trained_predictor=False, randomly initializing Predictor architecture")
-            import json
-            cfg_path = os.path.join(self.config.pretrained_predictor_path, 'config.json')
-            with open(cfg_path, 'r') as f:
-                arch = json.load(f)
-            print("model_config: ", arch)
-            model = Kronos(
-                s1_bits=arch.get('s1_bits', 10),
-                s2_bits=arch.get('s2_bits', 10),
-                n_layers=arch.get('n_layers', 12),
-                d_model=arch.get('d_model', 832),
-                n_heads=arch.get('n_heads', 16),
-                ff_dim=arch.get('ff_dim', 2048),
-                ffn_dropout_p=arch.get('ffn_dropout_p', 0.2),
-                attn_dropout_p=arch.get('attn_dropout_p', 0.0),
-                resid_dropout_p=arch.get('resid_dropout_p', 0.2),
-                token_dropout_p=arch.get('token_dropout_p', 0.0),
-                learn_te=arch.get('learn_te', True)
-            )
+            model = create_predictor_from_config(self.config.pretrained_predictor_path)
         model = model.to(self.device)
         
         model_size = sum(p.numel() for p in model.parameters())


### PR DESCRIPTION
## Summary

The `finetune_csv/` scripts contain ~400 lines of code duplicated from `finetune/` and between each other. This PR extracts shared utilities and fixes several bugs found during the deduplication:

- **New `finetune/utils/common.py`** with parameterized:
  - `setup_logging(name, log_dir, rank)` — was copy-pasted with only logger name differing
  - `create_dataloaders(dataset_class, config)` — identical in both finetune_csv scripts
  - `create_tokenizer_from_config(config_path)` — KronosTokenizer init block was copy-pasted 4 times
  - `create_predictor_from_config(config_path)` — Kronos predictor init block copy-pasted 2 times

- **Bug fixes**:
  - `set_seed(seed, rank)` in finetune_csv accepted `rank` param but silently ignored it — now uses shared version that correctly offsets seed by rank for DDP
  - Double `config = CustomFinetuneConfig(args.config)` loading in `finetune_tokenizer.py` — removed duplicate
  - Deprecated `fillna(method='ffill')` → `ffill()` in `finetune_base_model.py`

**Net result**: ~377 lines removed, ~151 lines added. All finetune_csv scripts now import from shared utils.

## Test plan

- [ ] `python finetune_csv/finetune_tokenizer.py --config ...` produces identical training behavior
- [ ] `python finetune_csv/finetune_base_model.py --config ...` produces identical training behavior
- [ ] `python finetune_csv/train_sequential.py --config ...` works end-to-end
- [ ] DDP training with multiple GPUs still works (seed correctly offset by rank)

🤖 Generated with [Claude Code](https://claude.com/claude-code)