### PR TITLE
fix: correct encoder/decoder block count to match configured layers

### DIFF
--- a/model/kronos.py
+++ b/model/kronos.py
@@ -59,12 +59,12 @@ class KronosTokenizer(nn.Module, PyTorchModelHubMixin):
         # Encoder Transformer Blocks
         self.encoder = nn.ModuleList([
             TransformerBlock(self.d_model, self.n_heads, self.ff_dim, self.ffn_dropout_p, self.attn_dropout_p, self.resid_dropout_p)
-            for _ in range(self.enc_layers - 1)
+            for _ in range(self.enc_layers)
         ])
         # Decoder Transformer Blocks
         self.decoder = nn.ModuleList([
             TransformerBlock(self.d_model, self.n_heads, self.ff_dim, self.ffn_dropout_p, self.attn_dropout_p, self.resid_dropout_p)
-            for _ in range(self.dec_layers - 1)
+            for _ in range(self.dec_layers)
         ])
         self.quant_embed = nn.Linear(in_features=self.d_model, out_features=self.codebook_dim) # Linear layer before quantization
         self.post_quant_embed_pre = nn.Linear(in_features=self.s1_bits, out_features=self.d_model) # Linear layer after quantization (pre part - s1 bits)


### PR DESCRIPTION
## Summary

`range(self.enc_layers - 1)` and `range(self.dec_layers - 1)` in `model/kronos.py` create one fewer TransformerBlock than the `n_enc_layers` / `n_dec_layers` parameters specify. With the default of `n_enc_layers=4`, only 3 encoder blocks are created. Same for decoder.

## Changes

- `model/kronos.py:62`: `range(self.enc_layers - 1)` -> `range(self.enc_layers)`
- `model/kronos.py:67`: `range(self.dec_layers - 1)` -> `range(self.dec_layers)`

## Why

The parameter name (`n_enc_layers`) and docstring ("Number of encoder layers") both indicate the user expects N blocks when passing N. The forward pass (`for layer in self.encoder`) iterates all blocks with no separate final layer, so the -1 has no compensating logic elsewhere.

The `embed` and `head` linear projections are separate from the transformer blocks and shouldn't count toward the configured layer count.

Fixes #219

This contribution was developed with AI assistance (Claude Code).