### PR TITLE
fix: use flexible dependency ranges in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
-numpy
-pandas
+numpy>=1.24.0
+pandas>=2.0.0
 torch>=2.0.0
 
-einops==0.8.1
-huggingface_hub==0.33.1
-matplotlib==3.9.3
-pandas==2.2.2
-tqdm==4.67.1
-safetensors==0.6.2
+einops>=0.8.0
+huggingface_hub>=0.20.0
+matplotlib>=3.7.0
+tqdm>=4.60.0
+safetensors>=0.4.0


### PR DESCRIPTION
## Summary

Replaces rigid `==` pinning with `>=` minimum versions so Kronos can be installed alongside other Python libraries without version conflicts.

## Changes

- Removed duplicate bare `pandas` entry (was listed both bare and as `pandas==2.2.2`)
- Added minimum version for `numpy` (was unpinned)
- Changed all `==` pins to `>=` with conservative minimums that preserve API compatibility
- `torch>=2.0.0` left unchanged (already flexible)

## Before/After

Before: `einops==0.8.1`, `pandas==2.2.2`, etc. - forces exact versions
After: `einops>=0.8.0`, `pandas>=2.0.0`, etc. - allows compatible upgrades

Fixes #213

This contribution was developed with AI assistance (Claude Code).