### PR TITLE
fix: correct typo accpeted -> accepted in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
 </div>
 
 ## 📰 News
-*   🚩 **[2025.11.10]** Kronos has been accpeted by AAAI 2026.
+*   🚩 **[2025.11.10]** Kronos has been accepted by AAAI 2026.
 *   🚩 **[2025.08.17]** We have released the scripts for fine-tuning! Check them out to adapt Kronos to your own tasks.
 *   🚩 **[2025.08.02]** Our paper is now available on [arXiv](https://arxiv.org/abs/2508.02739)!
 


### PR DESCRIPTION
Good day,

I noticed a small typo in the README file on line 53:
- Current: 'accpeted'
- Fixed: 'accepted'

This corrects the spelling for the AAAI 2026 acceptance announcement.

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly, RoomWithOutRoof