### PR TITLE
fix(sampling): top-k and top-p filters applied simultaneously

### DIFF
--- a/model/kronos.py
+++ b/model/kronos.py
@@ -349,7 +349,6 @@ def top_k_top_p_filtering(
         # Remove all tokens with a probability less than the last token of the top-k
         indices_to_remove = logits < torch.topk(logits, top_k)[0][..., -1, None]
         logits[indices_to_remove] = filter_value
-        return logits
 
     if top_p < 1.0:
         sorted_logits, sorted_indices = torch.sort(logits, descending=True)
@@ -367,14 +366,14 @@ def top_k_top_p_filtering(
         # scatter sorted tensors to original indexing
         indices_to_remove = sorted_indices_to_remove.scatter(1, sorted_indices, sorted_indices_to_remove)
         logits[indices_to_remove] = filter_value
-        return logits
+
+    return logits
 
 
 def sample_from_logits(logits, temperature=1.0, top_k=None, top_p=None, sample_logits=True):
     logits = logits / temperature
-    if top_k is not None or top_p is not None:
-        if top_k > 0 or top_p < 1.0:
-            logits = top_k_top_p_filtering(logits, top_k=top_k, top_p=top_p)
+    if (top_k is not None and top_k > 0) or (top_p is not None and top_p < 1.0):
+        logits = top_k_top_p_filtering(logits, top_k=top_k or 0, top_p=top_p or 1.0)
 
     probs = F.softmax(logits, dim=-1)
 


### PR DESCRIPTION
## Bug

`top_k_top_p_filtering` had an early `return logits` after the top-k block, so when both `top_k > 0` **and** `top_p < 1.0` were specified, the nucleus (top-p) filtering was silently skipped.

This violated the function docstring which says _"using top-k **and/or** nucleus (top-p) filtering"_ and meant callers like `predictor.predict(top_k=50, top_p=0.9)` would ignore the top-p threshold entirely.

Additionally, `sample_from_logits` could raise `TypeError` when only one of `top_k`/`top_p` was `None` (e.g. `top_k=None, top_p=0.9`), because the old guard `top_k > 0` would compare `None > 0`.

## Fix

**`top_k_top_p_filtering`**: Removed the early return after top-k filtering so both filters can be applied sequentially (top-k first, then top-p on the already-filtered distribution).

**`sample_from_logits`**:
- Guard now uses `(top_k is not None and top_k > 0) or (top_p is not None and top_p < 1.0)` — no TypeError when one arg is None.
- Normalizes None to defaults (`top_k or 0`, `top_p or 1.0`) before calling the filter function.

## Scope

Minimal, single-file change (4 lines changed in `model/kronos.py`). No dependency changes, no new files.

Note: PR #238 touches related code but is currently in a merge-conflict state (`dirty`) and bundles additional unrelated changes (pyproject.toml, uv.lock, conftest.py). This PR is a focused alternative that only addresses the sampling filter bug.