### PR TITLE
fix(finetune): prevent data leakage in CustomKlineDataset normalization

### DIFF
--- a/finetune_csv/finetune_base_model.py
+++ b/finetune_csv/finetune_base_model.py
@@ -121,8 +121,11 @@ class CustomKlineDataset(Dataset):
         
         x = window_data[self.feature_list].values.astype(np.float32)
         x_stamp = window_data[self.time_feature_list].values.astype(np.float32)
-        
-        x_mean, x_std = np.mean(x, axis=0), np.std(x, axis=0)
+
+        # Compute normalization stats only on the lookback portion to prevent
+        # future data leakage into the prediction window statistics.
+        past_x = x[:self.lookback_window]
+        x_mean, x_std = np.mean(past_x, axis=0), np.std(past_x, axis=0)
         x = (x - x_mean) / (x_std + 1e-5)
         x = np.clip(x, -self.clip, self.clip)
         


### PR DESCRIPTION
## Bug

`CustomKlineDataset.__getitem__` computes `np.mean(x)` and `np.std(x)` over the **entire** sliding window (`lookback_window + predict_window + 1` rows), which includes the prediction target period.

This leaks future price statistics (mean and std of the prediction window) into the training features. The model can indirectly infer information about upcoming prices through the normalization parameters.

The sibling dataset `QlibDataset` in `finetune/dataset.py` handles this correctly:
```python
# QlibDataset — correct
past_x = x[:past_len]
x_mean = np.mean(past_x, axis=0)
x_std  = np.std(past_x, axis=0)
```

## Fix

Restrict normalization statistics to the lookback portion only (`x[:self.lookback_window]`), matching the approach in `QlibDataset`.

3 lines changed. No API changes.