### PR TITLE
Fix: save_pretrained saves tokenizer weights, replace with safetensor…

### DIFF
--- a/finetune/train_predictor.py
+++ b/finetune/train_predictor.py
@@ -8,7 +8,7 @@ import torch
 from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 from torch.nn.parallel import DistributedDataParallel as DDP
-
+import safetensors.torch 
 import comet_ml
 
 # Ensure project root is in path
@@ -170,9 +170,13 @@ def train_model(model, tokenizer, device, config, save_dir, logger, rank, world_
             if avg_val_loss < best_val_loss:
                 best_val_loss = avg_val_loss
                 save_path = f"{save_dir}/checkpoints/best_model"
-                model.module.save_pretrained(save_path)
+                # 修复：直接保存 Predictor 模型权重，避免保存为 Tokenizer
+                os.makedirs(save_path, exist_ok=True)
+                safetensors.torch.save_file(
+                    model.module.state_dict(),
+                    os.path.join(save_path, "model.safetensors")
+                )
                 print(f"Best model saved to {save_path} (Val Loss: {best_val_loss:.4f})")
-
         dist.barrier()
 
     dt_result['best_val_loss'] = best_val_loss


### PR DESCRIPTION
## Issue / 问题
When running `train_predictor.py`, calling `model.module.save_pretrained()` saves **tokenizer weights (encoder/decoder)** instead of the trained Predictor model.
- Saved checkpoint size: only ~16MB
- Missing core Predictor weights: `transformer.0 ~ transformer.11`
- Trained model cannot be loaded for inference

运行 `train_predictor.py` 时，调用 `model.module.save_pretrained()` 保存的并非训练后的预测模型，而是**分词器（Tokenizer）权重（encoder/decoder）**。
- 保存的模型文件大小仅约 16MB
- 缺失预测模型核心权重：`transformer.0 ~ transformer.11`
- 训练完成的模型无法加载并用于推理

## Root Cause / 根本原因
The custom `Kronos` model's `save_pretrained()` method incorrectly serializes tokenizer weights instead of the main model weights.

自定义 `Kronos` 模型的 `save_pretrained()` 方法存在错误，错误地序列化了分词器权重，而非主模型权重。

## Fix / 修复方案
Replace the broken `save_pretrained()` with direct `safetensors` state_dict saving to ensure the full Predictor model weights are saved correctly.

替换存在问题的 `save_pretrained()` 方法，直接通过 `safetensors` 保存模型权重字典，确保完整、正确地保存预测模型权重。

## Changes / 修改内容
1. Add `safetensors.torch` import
2. Replace model saving logic in `train_predictor.py`
3. Minimal non-breaking change

1. 新增 `safetensors.torch` 导入语句
2. 替换 `train_predictor.py` 中的模型保存逻辑
3. 最小化修改，无破坏性变更